### PR TITLE
modification des quotes

### DIFF
--- a/dour_base_dialog.py
+++ b/dour_base_dialog.py
@@ -1059,25 +1059,25 @@ class DourBaseDialog(QDialog):
             f"* fichiers shp : {self.SHP}\n"
             f"* depco : {depco}\n"
             f"* num_source : {num_source}\n"
-            f'* aep : {'non' if aep == '' else 'oui'}\n'
-            f'* eu : {'non' if eu == '' else 'oui'}\n'
-            f'* epl : {'non' if epl == '' else 'oui'}\n'
-            f'* cote : {'non' if cote == '' else 'oui'}\n'
-            f'* utilisat : {utilisat}\n'
-            f'* no_origine : {'Données vides' if no_origine == '' else no_origine}\n'
-            f'* localisat : {'localisat non renseigné' if localisat == '' else localisat}\n'
-            f'* date de plan : {date_str}\n'
-            f'* type de plan : {'type de plan non renseigné' if type_plan == '' else type_plan}\n'
-            f'* bureau d\'étude : {'bureau d\'étude non renseigné' if b_etude == '' else b_etude}\n'
-            f'* entreprise {entreprise}\n'
-            f'* échelle : {'échelle non renseigné' if echelle == '' else echelle}\n'
-            f'* etat : {etat}\n'
-            f'* Qualité de support : {q_support}\n'
-            f'* nom du fichier : {nom_fichier}\n'
-            f'* moa : {moa}\n'
-            f'* id source : {id_source}\n'
-            f'* exploitant : {exploitant}\n'
-            f'* fichiers shp : {shp_files}\n'
+            f"* aep : {'non' if aep == '' else 'oui'}\n"
+            f"* eu : {'non' if eu == '' else 'oui'}\n"
+            f"* epl : {'non' if epl == '' else 'oui'}\n"
+            f"* cote : {'non' if cote == '' else 'oui'}\n"
+            f"* utilisat : {utilisat}\n"
+            f"* no_origine : {'Données vides' if no_origine == '' else no_origine}\n"
+            f"* localisat : {'localisat non renseigné' if localisat == '' else localisat}\n"
+            f"* date de plan : {date_str}\n"
+            f"* type de plan : {'type de plan non renseigné' if type_plan == '' else type_plan}\n"
+            f"* bureau d\'étude : {'bureau d\'étude non renseigné' if b_etude == '' else b_etude}\n"
+            f"* entreprise {entreprise}\n"
+            f"* échelle : {'échelle non renseigné' if echelle == '' else echelle}\n"
+            f"* etat : {etat}\n"
+            f"* Qualité de support : {q_support}\n"
+            f"* nom du fichier : {nom_fichier}\n"
+            f"* moa : {moa}\n"
+            f"* id source : {id_source}\n"
+            f"* exploitant : {exploitant}\n"
+            f"* fichiers shp : {shp_files}\n"
         )
         self.log_to_console(text)
 


### PR DESCRIPTION
**suite à une erreur** 

Impossible de charger l'extension 'DourBase' provoque une erreur lors de l'appel à sa méthode classFactory() 

SyntaxError: f-string: expecting '}' 
Traceback (most recent call last):
  File "C:\PROGRA~1/QGIS33~1.5/apps/qgis-ltr/./python\qgis\utils.py", line 423, in _startPlugin
    plugins[packageName] = package.classFactory(iface)
  File "C:\Users/apasquier/AppData/Roaming/QGIS/QGIS3\profiles\Alain/python/plugins\DourBase\__init__.py", line 2, in classFactory
    from .dour_base import DourBase
  File "C:\PROGRA~1/QGIS33~1.5/apps/qgis-ltr/./python\qgis\utils.py", line 892, in _import
    mod = _builtin_import(name, globals, locals, fromlist, level)
  File "C:\Users/apasquier/AppData/Roaming/QGIS/QGIS3\profiles\Alain/python/plugins\DourBase\dour_base.py", line 6, in 
    from .dour_base_dialog import DourBaseDialog
  File "C:\PROGRA~1/QGIS33~1.5/apps/qgis-ltr/./python\qgis\utils.py", line 892, in _import
    mod = _builtin_import(name, globals, locals, fromlist, level)
  File "C:\Users/apasquier/AppData/Roaming/QGIS/QGIS3\profiles\Alain/python/plugins\DourBase\dour_base_dialog.py", line 1062
    f'* aep : {'non' if aep == '' else 'oui'}\n'
                ^
SyntaxError: f-string: expecting '}'


Version de Python : 3.9.18 (heads/master:5eba59e, Feb  1 2024, 20:02:10) [MSC v.1929 64 bit (AMD64)] 
Version de QGIS : 3.34.5-Prizren Prizren, 4b308492 